### PR TITLE
fix: github action build scripts (#23)

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,0 +1,25 @@
+name: Go Build
+on: [push]
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v3
+
+    - name: Set up Go
+      uses: actions/setup-go@v3
+      with:
+        go-version: 1.21
+
+    - name: Build and tests
+      env:
+        CODACY_PROJECT_TOKEN: ${{ secrets.CODACY_PROJECT_TOKEN }}
+        LANG: en_US.UTF-8
+      # using --trace has a side effect on the the test output.
+      run: make --file=config/Makefile.base all
+
+    - name: Send coverage report
+      uses: shogo82148/actions-goveralls@v1
+      with:
+        path-to-profile: ./build/test-all.cover

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,4 +1,4 @@
-name: Go
+name: Go Release
 on: [push]
 jobs:
   build:
@@ -11,18 +11,6 @@ jobs:
       uses: actions/setup-go@v3
       with:
         go-version: 1.21
-
-    - name: Build and tests
-      env:
-        CODACY_PROJECT_TOKEN: ${{ secrets.CODACY_PROJECT_TOKEN }}
-        LANG: en_US.UTF-8
-      # using --trace has a side effect on the the test output.
-      run: make --file=config/Makefile.base all
-
-    - name: Send coverage report
-      uses: shogo82148/actions-goveralls@v1
-      with:
-        path-to-profile: ./build/test-all.cover
 
     - name: Release new version
       env:


### PR DESCRIPTION
This pull request splits the github action build scripts to split the actions into a build and release part.