### PR TITLE
feat: add support for stdin (#62)

### DIFF
--- a/Makefile.ext
+++ b/Makefile.ext
@@ -51,3 +51,21 @@ test-compat::
 	COMPAT="$$(BASH_COMPAT=3.2 make --makefile=$(GOMAKE_MAKEFILE) test-self 2>&1)" && \
 	DIFF="$$(diff <(echo "$${ACTUAL}") <(echo "$${COMPAT}"))" && \
 	echo "info: test-compat finished successful!!" || echo "$${DIFF}";
+
+CI_IMAGE_VERSION ?= latest
+CI_IMAGE ?= pierone.stups.zalan.do/cdp-runtime/go:${CI_IMAGE_VERSION}
+#@ test build in continuous integration container.
+test-cdp:
+	@if tty -s; then TTY="--tty"; fi; ( \
+	  echo "machine github.bus.zalan.do"; \
+	  echo "login $${USER}"; \
+      echo "password $${GITOKEN}" \
+	) > $(DIR_RUN)/.netrc; \
+	docker run --interactive $${TTY} --rm --privileged \
+	  --workdir="/workspace" --volume=$${PWD}:/workspace \
+	  --volume=/var/run/docker.sock:/var/run/docker.sock \
+	  --volume=$${HOME}/.gitconfig:/root/.gitconfig \
+      --volume=$(DIR_RUN).netrc:/root/.netrc \
+	  ${CI_IMAGE} /bin/bash
+
+#	  --volume=$${HOME}/.ssh:/root/.ssh \

--- a/config/Makefile.base
+++ b/config/Makefile.base
@@ -15,7 +15,7 @@ mwarning = $(strip \033[1;93mwarning:\033[0m $(1))
 mfailure = $(strip \033[1;91mfailure:\033[0m $(1))
 msuccess = $(strip \033[1;92msuccess:\033[0m $(1))
 
-cerror = $(error $(shell echo -e "$(call merror,"$(1)")" >/dev/stderr))
+cerror = $(error $(shell echo -e "$(call merror,"$(1)")" > /dev/stderr))
 
 # Finding: \$\((call )?(topic|cmd|arg)
 topic = \033[1;97m$(1)\033[0m
@@ -30,7 +30,7 @@ endif
 # Check whether bash is running in minmal compatibility mode for testing.
 ifdef BASH_COMPAT
   $(shell echo -e "$(call minfo,bash compatibility mode set \
-    [$(BASH_COMPAT)])" >/dev/stderr)
+    [$(BASH_COMPAT)])" > /dev/stderr)
 endif
 
 # Setup default makeflags create consistent behavior.
@@ -319,7 +319,7 @@ COMMANDS_SH := $(sort $(call go-pkg,$(TOOLS_SH),command,$(COMMANDS_REGEX),not,))
 
 
 # Setup of runtime arguments for commands that support arguments.
-CMDWORDS ?= show git- test- lint run- version- update
+CMDWORDS ?= call show git- test- lint run- version- update
 CMDARGS ?= $(shell  awk '{ split("$(CMDWORDS)",seps); \
 	  for (i = 1; i <= NF; i++) { if (found) { \
 	    line = ((line) ? line " " $$i : $$i); continue \
@@ -329,7 +329,7 @@ CMDARGS ?= $(shell  awk '{ split("$(CMDWORDS)",seps); \
 ifdef CMDARGS
   ARGS := $(strip $(CMDARGS) $(ARGS))
   $(shell if [ -n "$(ARGS)" ]; then \
-    echo -e "$(call minfo,captured arguments [$(ARGS)])" >/dev/stderr; \
+    echo -e "$(call minfo,captured arguments [$(ARGS)])" > /dev/stderr; \
   fi)
   $(eval $(subst :,\:,$(CMDARGS))::;@:)
 endif
@@ -409,6 +409,9 @@ all:: $(TARGETS_ALL)
 all-clean:: clean clean-run all
 #@ executes the pre-commit check targets.
 commit:: $(TARGETS_COMMIT)
+##@ executes the given arguments as commands (for testing).
+call::;	@$(ARGS)
+
 
 $(DIR_BUILD) $(DIR_RUN) $(DIR_CRED) $(GOBIN):
 	@if [ ! -d "$@" ]; then mkdir -p $@; fi;
@@ -602,7 +605,7 @@ git-verify::
 	( "branch" ) $(GIT) log --no-merges --format=raw "$$($(GITBRANCH))";; \
 	( "pull" | * ) MAIN="$(git-main)" && $(GIT) fetch origin "$${MAIN}" --verbose && \
 	  $(GIT) log --no-merges --format=raw "$$($(GITBRANCH))" "^origin/$${MAIN}";; \
-	esac | $(call git-verify,$${MODE}) >/dev/stderr
+	esac | $(call git-verify,$${MODE}) > /dev/stderr
 
 #@ <branch> <message> # creates a branch with the current change set using next issue.
 git-create:: git-create-feat
@@ -654,12 +657,12 @@ go.mod:
 #@ initialize git pre-commit and commit-message hooks.
 init-hooks:: $(GITHOOKS:%=.git/hooks/%)
 git-hooks-commit-msg = echo -ne '\#!/bin/sh\n\n\
-	echo "make git-verify message $${1}" >/dev/stderr;\n\
+	echo "make git-verify message $${1}" > /dev/stderr;\n\
 	command -v $(GOBIN)/go-make >/dev/null || \\\n\
 	GOBIN=$(GOBIN) $(GO) install $(INSTALL_FLAGS) $(GOMAKE_DEP) && \\\n\
 	$(GOBIN)/go-make git-verify message $${1};\n' | sed 's/^ *//g'
 git-hooks-pre-commit = echo -ne '\#!/bin/sh\n\n\
-	echo "make commit" >/dev/stderr;\n\
+	echo "make commit" > /dev/stderr;\n\
 	command -v $(GOBIN)/go-make >/dev/null || \\\n\
 	GOBIN=$(GOBIN) $(GO) install $(INSTALL_FLAGS) $(GOMAKE_DEP) && \\\n\
 	$(GOBIN)/go-make commit;\n' | sed 's/^ *//g'
@@ -838,6 +841,7 @@ $(TEST_BENCH):: $(SOURCES) init-sources $(DIR_BUILD)
 #@ execute a kind of self-test running the main targets.
 test-self:: update-all? update-all clean-all all-clean install-all
 	@echo -e "$(call msuccess,test-self finished successfully!)";
+
 
 # disabled (deprecated): deadcode golint interfacer ifshort maligned musttag
 #   nosnakecase rowserrcheck scopelint structcheck varcheck wastedassign
@@ -1378,10 +1382,10 @@ run-db:: $(DIR_RUN)
 	  $(ARGS) 2>&1 & \
 	until [ "$$($(IMAGE_CMD) inspect --format {{.State.Running}} \
 	  $(IMAGE_ARTIFACT)-db 2>/dev/null)" == "true" ]; \
-	do echo "waiting for db container" >/dev/stderr; sleep 1; done && \
+	do echo "waiting for db container" > /dev/stderr; sleep 1; done && \
 	until $(IMAGE_CMD) exec $(IMAGE_ARTIFACT)-db \
 	  pg_isready -h localhost -U $(DB_USER) -d $(DB_NAME); \
-	do echo "waiting for db service" >/dev/stderr; sleep 1; done) |\
+	do echo "waiting for db service" > /dev/stderr; sleep 1; done) |\
 	tee -a $(DIR_RUN)/$(IMAGE_ARTIFACT)-db;
 
 #@ start an AWS localstack instance for testing.
@@ -1399,10 +1403,10 @@ run-aws:: $(DIR_RUN)
 	  --env SERVICES="$(AWS_SERVICES)" $(AWS_IMAGE) $(ARGS) 2>&1 && \
 	until [ "$$($(IMAGE_CMD) inspect --format {{.State.Running}} \
 	  $(IMAGE_ARTIFACT)-aws 2>/dev/null)" == "true" ]; \
-	do echo "waiting for aws container" >/dev/stderr; sleep 1; done && \
+	do echo "waiting for aws container" > /dev/stderr; sleep 1; done && \
 	until $(IMAGE_CMD) exec $(IMAGE_ARTIFACT)-aws \
 	  curl --silent http://$(HOST):4566; \
-	do echo "waiting for aws service" >/dev/stderr; sleep 1; done && \
+	do echo "waiting for aws service" > /dev/stderr; sleep 1; done && \
 	$(call run-setup-aws) || exit 1) | \
 	tee -a $(DIR_RUN)/$(IMAGE_ARTIFACT)-aws.log;
 
@@ -1426,10 +1430,10 @@ $(TARGETS_RUN_IMAGE):: run-image-%: $(RUN_DEPS) $(DIR_RUN) $(DIR_CRED)
 	trap "$(IMAGE_CMD) kill $(IMAGE_ARTIFACT)-$* >/dev/null" INT TERM; \
 	if [ -n "$(filter %$*,$(TARGETS_IMAGE))" ]; then \
 	  IMAGE="$$(echo "$(IMAGE)" | sed -e "s/:/-$*:/")"; \
-	else IMAGE="$(IMAGE)" fi; $(call run-setup) && \
-	$(IMAGE_CMD) run --name $(IMAGE_ARTIFACT)-$* --network=host \
+	else IMAGE="$(IMAGE)"; fi && if tty -s; then TTY=" --tty"; fi && \
+	$(call run-setup) && $(IMAGE_CMD) run$${TTY} --name $(IMAGE_ARTIFACT)-$* \
 	  --volume $(DIR_CRED):/meta/credentials --volume $(DIR_RUN)/temp:/tmp \
-	  $(call run-vars,--env) $(call run-vars-image,--env) \
+	  --network=host $(call run-vars,--env) $(call run-vars-image,--env) \
 	  ${IMAGE} /$* $(ARGS) 2>&1 | \
 	tee -a $(DIR_RUN)/$(IMAGE_ARTIFACT)-$*.log; \
 	exit $${PIPESTATUS[0]};
@@ -1512,7 +1516,7 @@ update-go::
 	done; \
 	if ! [[ "$(GOVERSION)" =~ ^$${VERSION}[0-9.]*$$ ]]; then \
 	  echo -e "$(call mwarning, current compiler differs \
-	    [$(GOVERSION) => $${VERSION}])" >/dev/stderr; \
+	    [$(GOVERSION) => $${VERSION}])" > /dev/stderr; \
 	fi; \
 
 #@ check whether a new latest go version exists.
@@ -1576,7 +1580,7 @@ update/go.mod?:: install-gomajor
 	$(call update-list,$${ARGS},all); mv go.sum.~save~ go.sum;
 update/go-make::
 	@$(call update-config,$(ARGS),download) || \
-	  ( echo "error: downloading $${GOMAKE}" >/dev/stderr && exit 1 )
+	  ( echo "error: downloading $${GOMAKE}" > /dev/stderr && exit 1 )
 
 #@ <version> # update this build environment to latest version.
 update-make:: update/go-make $(TARGETS_UPDATE_MAKE)

--- a/internal/cmd/cmd.go
+++ b/internal/cmd/cmd.go
@@ -9,9 +9,16 @@ import (
 
 // Executor provides a common interface for executing commands.
 type Executor interface {
-	// Exec executes the command with given name and arguments in given
-	// directory redirecting stdout and stderr to given writers.
-	Exec(stdout, stderr io.Writer, dir string, env []string, args ...string) error
+	// Exec executes the command provided by given arguments in given working
+	// directory using stdin as input while redirecting stdout and stderr to
+	// given writers.
+	Exec(stdin io.Reader, stdout, stderr io.Writer,
+		dir string, env []string, args ...string) error
+	// ExecPty executes the command with given name and arguments in given
+	// directory using a pseudo terminal defined by the given file for input
+	// and output.
+	// ExecPty(stdin, stdout, stderr *os.File,
+	// 	dir string, env []string, args ...string) error
 }
 
 // defaultExecutor provides a default command executor using `os/exec`
@@ -23,16 +30,88 @@ func NewExecutor() Executor {
 	return &defaultExecutor{}
 }
 
-// Exec executes the command with given name and arguments in given directory
-// redirecting stdout and stderr to given writers.
+// Exec executes the command provided by given arguments in given working
+// directory using stdin as input while redirecting stdout and stderr to given
+// writers.
 func (*defaultExecutor) Exec(
-	stdout, stderr io.Writer, dir string, env []string, args ...string,
+	stdin io.Reader, stdout, stderr io.Writer,
+	dir string, env []string, args ...string,
 ) error {
 	// #nosec G204 -- caller ensures safe commands
 	cmd := exec.Command(args[0], args[1:]...)
 	cmd.Dir, cmd.Env = dir, os.Environ()
 	cmd.Env = append(cmd.Env, env...)
-	cmd.Stdout, cmd.Stderr = stdout, stderr
 
+	cmd.Stdin, cmd.Stdout, cmd.Stderr = stdin, stdout, stderr
 	return cmd.Run() //nolint:wrapcheck // checked on next layer
 }
+
+// // ExecPty executes the command with given name and arguments in given
+// // directory using a pseudo terminal defined by the given file for input
+// // and output.
+// func (e *defaultExecutor) ExecPty(
+// 	stdin, stdout, stderr *os.File,
+// 	dir string, env []string, args ...string,
+// ) error {
+// 	// #nosec G204 -- caller ensures safe commands
+// 	cmd := exec.Command(args[0], args[1:]...)
+// 	cmd.Dir, cmd.Env = dir, os.Environ()
+// 	cmd.Env = append(cmd.Env, env...)
+
+// 	if ptmx, err := pty.Start(cmd); err == nil {
+// 		resetTermResize := e.ptyTermResize(ptmx, stdin, stderr)
+// 		resetTermRaw := e.ptyTermRaw(stdin)
+
+// 		defer func() {
+// 			resetTermResize()
+// 			resetTermRaw()
+// 			_ = ptmx.Close()
+// 		}()
+
+// 		eg := errgroup.Group{}
+// 		eg.Go(func() error {
+// 			_, err := io.Copy(stdin, ptmx)
+// 			return err //nolint:wrapcheck // checked on next layer
+// 		})
+// 		eg.Go(func() error {
+// 			_, err := io.Copy(ptmx, stdout)
+// 			return err //nolint:wrapcheck // checked on next layer
+// 		})
+// 		return eg.Wait() //nolint:wrapcheck // checked on next layer
+// 	} else {
+// 		return err //nolint:wrapcheck // checked on next layer
+// 	}
+// }
+
+// // ptyTermResize connects the pseudo terminal to the given file descriptor to
+// // support resizing of the terminal. It returns a cleanup function that needs
+// // to be called when the pseudo terminal is closed.
+// func (*defaultExecutor) ptyTermResize(
+// 	ptmx *os.File, stdin, stderr *os.File,
+// ) func() {
+// 	ch := make(chan os.Signal, 1)
+// 	signal.Notify(ch, syscall.SIGWINCH)
+
+// 	go func() {
+// 		for range ch {
+// 			if err := pty.InheritSize(stdin, ptmx); err != nil {
+// 				fmt.Fprintf(stderr, "error resizing pty: %s", err)
+// 			}
+// 		}
+// 	}()
+
+// 	ch <- syscall.SIGWINCH
+
+// 	return func() { signal.Stop(ch); close(ch) }
+// }
+
+// // ptyTermRaw enables the raw mode of the given file descriptor and returns a
+// // clean up function that needs to be called when the pseudo terminal is
+// // closed.
+// func (*defaultExecutor) ptyTermRaw(file *os.File) func() {
+// 	if state, err := term.MakeRaw(int(file.Fd())); err == nil {
+// 		return func() { _ = term.Restore(int(file.Fd()), state) }
+// 	} else {
+// 		panic(err)
+// 	}
+// }

--- a/internal/cmd/cmd_test.go
+++ b/internal/cmd/cmd_test.go
@@ -5,35 +5,54 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+
 	"github.com/tkrop/go-make/internal/cmd"
 	"github.com/tkrop/go-testing/test"
 )
 
-type ExecutorParams struct {
-	env          []string
+type ExecParams struct {
 	args         []string
+	env          []string
+	stdin        string
 	expectStdout string
 	expectStderr string
 	expectError  error
 }
 
-var testExecutorParams = map[string]ExecutorParams{
-	"ls": {
-		args:         []string{"ls"},
-		expectStdout: "cmd.go\ncmd_test.go\n",
+var testExecParams = map[string]ExecParams{
+	"cat": {
+		args:         []string{"cat", "-"},
+		stdin:        "Hello, World!",
+		expectStdout: "Hello, World!",
+	},
+	"echo": {
+		args:         []string{"echo", "Hello, World!"},
+		expectStdout: "Hello, World!\n",
+	},
+	"bash stdout": {
+		args:         []string{"bash"},
+		stdin:        "echo Hello, World!\n",
+		expectStdout: "Hello, World!\n",
+	},
+	"bash stderr": {
+		args:         []string{"bash"},
+		stdin:        "echo Hello, World! > /dev/stderr\n",
+		expectStderr: "Hello, World!\n",
 	},
 }
 
-func TestExecutor(t *testing.T) {
-	test.Map(t, testExecutorParams).
-		Run(func(t test.Test, param ExecutorParams) {
+func TestExec(t *testing.T) {
+	test.Map(t, testExecParams).
+		Run(func(t test.Test, param ExecParams) {
 			// Given
 			exec := cmd.NewExecutor()
 			stdout := &strings.Builder{}
 			stderr := &strings.Builder{}
+			stdin := strings.NewReader(param.stdin)
 
 			// When
-			err := exec.Exec(stdout, stderr, ".", param.env, param.args...)
+			err := exec.Exec(stdin, stdout, stderr,
+				".", param.env, param.args...)
 
 			// Then
 			assert.Equal(t, param.expectError, err)
@@ -41,3 +60,52 @@ func TestExecutor(t *testing.T) {
 			assert.Equal(t, param.expectStderr, stderr.String())
 		})
 }
+
+// var testExecPtyParams = map[string]ExecParams{
+// 	"bash-error": {
+// 		args:  []string{"bash"},
+// 		stdin: "echo Hello, World!",
+// 		expectError: &fs.PathError{
+// 			Op: "fork/exec", Path: "/usr/bin/bash",
+// 			Err: errors.New("Setctty set but Ctty not valid in child"),
+// 		},
+// 	},
+// 	"bash-interactive": {
+// 		args:         []string{"bash"},
+// 		stdin:        "echo Hello, World!\n\x03",
+// 		expectStdout: "Hello, World!\n",
+// 	},
+// }
+
+// func TestExecPty(t *testing.T) {
+// 	test.Map(t, testExecPtyParams).
+// 		Run(func(t test.Test, param ExecParams) {
+// 			// Given
+// 			exec := cmd.NewExecutor()
+
+// 			dir := t.TempDir()
+// 			stdin, err := os.OpenFile(filepath.Join(dir, "stdin"),
+// 				os.O_CREATE+os.O_WRONLY, 0o644)
+// 			assert.NoError(t, err)
+// 			_, err = stdin.Write([]byte(param.stdin))
+// 			assert.NoError(t, err)
+// 			stdin, err = os.OpenFile(filepath.Join(dir, "stdin"),
+// 				os.O_RDONLY, 0o644)
+// 			assert.NoError(t, err)
+
+// 			stdout, err := os.OpenFile(filepath.Join(dir, "stdout"),
+// 				os.O_CREATE+os.O_WRONLY, 0o644)
+// 			assert.NoError(t, err)
+// 			stderr, err := os.OpenFile(filepath.Join(dir, "stderr"),
+// 				os.O_CREATE+os.O_WRONLY, 0o644)
+// 			assert.NoError(t, err)
+
+// 			// When
+// 			err = exec.ExecPty(stdin, stdout, stderr, ".", param.env, param.args...)
+
+// 			// Then
+// 			assert.Equal(t, param.expectError, err)
+// 			// assert.Equal(t, param.expectStdout, stdout.String())
+// 			// assert.Equal(t, param.expectStderr, stderr.String())
+// 		})
+// }

--- a/internal/log/logger_test.go
+++ b/internal/log/logger_test.go
@@ -73,16 +73,16 @@ var testExecParams = map[string]ExecParams{
 		expectString: "exec: arg1 arg2 []\n",
 	},
 
-	"empty args with dir": {
+	"dir empty args": {
 		dir:          "dir",
 		expectString: "exec: [dir]\n",
 	},
-	"single arg with dir": {
+	"dir single arg": {
 		dir:          "dir",
 		args:         []string{"arg"},
 		expectString: "exec: arg [dir]\n",
 	},
-	"multiple args with dir": {
+	"dir multiple args": {
 		dir:          "dir",
 		args:         []string{"arg1", "arg2"},
 		expectString: "exec: arg1 arg2 [dir]\n",

--- a/internal/make/fixtures/targets/std.out
+++ b/internal/make/fixtures/targets/std.out
@@ -4,6 +4,7 @@ build
 build-image
 build-linux
 build-native
+call
 clean
 clean-all
 clean-build

--- a/internal/make/fixtures/targets/trace.out
+++ b/internal/make/fixtures/targets/trace.out
@@ -8,6 +8,7 @@ build
 build-image
 build-linux
 build-native
+call
 clean
 clean-all
 clean-build

--- a/main.go
+++ b/main.go
@@ -35,7 +35,7 @@ func NewInfo() *info.Info {
 
 // main is the main entry point of the go-make command.
 func main() {
-	os.Exit(make.Make(os.Stdout, os.Stderr, NewInfo(),
+	os.Exit(make.Make(os.Stdin, os.Stdout, os.Stderr, NewInfo(),
 		make.GetEnvDefault(make.EnvGoMakeConfig, Config),
 		".", nil, os.Args...))
 }


### PR DESCRIPTION
This pull request adds support for reading from standard input in make targets. This way we can run interactive docker containers and read input from pipes in targets. One main use case is to test `go-make` while running within a build container, but this may become handy in other situations too.

The pull request also contains code to establish a `pty`-server connection, but is it turned out during testing this seems to be unnecessary.