### PR TITLE
Update make.go to account for default MacOS sed version

### DIFF
--- a/internal/make/make.go
+++ b/internal/make/make.go
@@ -43,7 +43,7 @@ const (
 	// CompleteFilterFunc provides the common filter function to filter
 	// go-make targets before applying completion.
 	CompleteFilterFunc = "_go-make-filter() {\n" +
-		"    sed --regexp-extended \"s|^(${1}[^/-]*[-/]?)?.*|\\1|g\"" +
+		"    sed -E -e \"s|^(${1}[^/-]*[-/]?)?.*|\\1|g\"" +
 		" | sort --unique;\n" +
 		"};\n"
 	// CompleteBash provides the bash completion setup for go-make.


### PR DESCRIPTION
This PR modifies the filter function of the completion script to account for default MacOS utils.