### PR TITLE
fix: hanging in awk version check on MacOS (#0)

### DIFF
--- a/config/Makefile.base
+++ b/config/Makefile.base
@@ -99,7 +99,7 @@ $(call cdebug,using SHELL [$${SHELL}])
 $(call cdebug,using PATH [$${PATH}])
 $(call cdebug,using SHELL [$${SHELL}])
 $(call cdebug,using BASH [$${0} - $${BASH_VERSION}])
-$(call cdebug,using AWK [$(shell awk -W version 2>/dev/null)])
+$(call cdebug,using AWK [$(shell which awk)])
 
 # Helper function to find and remove source files.
 find-all = find $(1) ! -path "./.git/*" ! -path "./run/*" ! -path "./build/*" \


### PR DESCRIPTION
The `awk` distributed in MacOS does not recognize `-W` argument, so it hangs infinitely in the initial run.

I am suggesting to reference which awk binary is being used to change this to be a widely compatible approach for `awk` instead.