### PR TITLE
chore: update deps (#160)

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,17 +115,34 @@ satisfied by the runtime environment, e.g. using [`ubuntu-20.04`][ubuntu-20.04],
 * [GNU `sed`][sed] (^4.7)
 * [`curl`][curl] (^7)
 
-**Note:** Since [`MacOSX`][mac-osx] comes with heavily outdated GNU tools,
-[`go-make`][go-make] is ensures that these are available in recent versions
-using the [`brew`][brew] package manager. As a consequence it only requires
-[`go`][go] and [GNU `make`] in a decent version that is usually satisfied by
-the standard MacOS installation.
+For non-core-features it requires [`docker`][docker]/[`podman`][podman] and
+[`curl`][curl].
+
+**Note:** Since [`MacOSX`][mac-osx] comes with heavily outdated GNU tools.
+[`go-make`][go-make] ensures that recent versions are installed using the
+[`brew`][brew] package manager. As a consequence it only requires [`go`][go]
+and [GNU `make`] in a decent version that is usually satisfied by the standard
+MacOS installation. [`docker`][docker]/[`podman`][podman] are not supported
+out-of-the-box.
 
 [ubuntu-20.04]: <https://releases.ubuntu.com/focal/>
 [ubuntu-22.04]: <https://releases.ubuntu.com/jammy/>
 [ubuntu-24.04]: <https://releases.ubuntu.com/noble/>
 [mac-osx]: <https://support.apple.com/en-gb/mac>
 [go-install]: <https://go.dev/doc/tutorial/compile-install>
+
+[make]: <https://www.gnu.org/software/make/>
+[bash]: <https://www.gnu.org/software/bash/>
+[core]: <https://www.gnu.org/software/coreutils/>
+[find]: <https://www.gnu.org/software/findutils/>
+[awk]: <https://www.gnu.org/software/awk/>
+[sed]: <https://www.gnu.org/software/sed/>
+
+[go]: <https://go.dev/>
+[brew]: <https://brew.sh/>
+[curl]: <https://curl.se/>
+[docker]: <https://www.docker.com/>
+[podman]: <https://podman.io/>
 
 
 ## Example usage
@@ -169,43 +186,28 @@ into your [README.md].
 
 ### Project build/requirement notice
 
-This project is using [go-make][go-make], which provides default targets for
-most common tasks, to initialize, build, test, and run the software of this
-project. Read the [go-make manual][go-make-man] for more information about
-targets and configuration options.
+This project is using a custom build system called [go-make][go-make], that
+provides default targets for most common tasks. Makefile rules are generated
+based on the project structure and files for common tasks, to initialize,
+build, test, and run the components in this repository.
+
+To get started, run one of the following commands.
+
+```bash
+make help
+make show-targets
+```
+
+Read the [go-make manual][go-make-man] for more information about targets
+and configuration options.
+
+**Not:** [go-make][go-make] installs `pre-commit` and `commit-msg`
+[hooks][git-hooks] calling `make commit` to enforce successful testing and
+linting and `make git-verify message` to validate whether the commit message
+is following the [conventional commit][convent-commit] best practice.
 
 [go-make]: <https://github.com/tkrop/go-make>
 [go-make-man]: <https://github.com/tkrop/go-make/blob/main/MANUAL.md>
-
-The [`Makefile`](Makefile) depends on a preinstalled [`go`][go] for version
-management, and makes heavy use of GNU tools, i.e. [`coretils`][core],
-[`findutils`][find], ['(g)make'][make], [`(g)awk`][awk], [`(g)sed`][sed], and
-not the least [`bash`][bash]. For certain non-core-features it also requires
-[`docker`][docker]/[`podman`][podman] and [`curl`][curl]. On MacOS, it uses
-[brew][brew] to ensure that the latest versions with the exception
-[`docker`][docker]/[`podman`][podman] are.
-
-[go]: <https://go.dev/>
-[brew]: <https://brew.sh/>
-[curl]: <https://curl.se/>
-[docker]: <https://www.docker.com/>
-[podman]: <https://podman.io/>
-[make]: <https://www.gnu.org/software/make/>
-[bash]: <https://www.gnu.org/software/bash/>
-[core]: <https://www.gnu.org/software/coreutils/>
-[find]: <https://www.gnu.org/software/findutils/>
-[awk]: <https://www.gnu.org/software/awk/>
-[sed]: <https://www.gnu.org/software/sed/>
-
-**Note:** [go-make][go-make] automatically installs `pre-commit` and
-`commit-msg` [hooks][git-hooks] overwriting and deleting pre-existing hooks
-(see also [Customizing Git - Git Hooks][git-hooks]). The `pre-commit` hook
-calls `make commit` as an alias for executing  `test-go`, `test-unit`,
-`lint-<level>`, and `lint-markdown` to enforce successful testing and
-linting. The `commit-msg` hook calls `make git-verify message` for
-validating whether the commit message is following the [conventional
-commit][convent-commit] best practice.
-
 [git-hooks]: <https://git-scm.com/book/en/v2/Customizing-Git-Git-Hooks>
 [convent-commit]: <https://www.conventionalcommits.org/en/v1.0.0/>
 

--- a/go.mod
+++ b/go.mod
@@ -1,12 +1,12 @@
 module github.com/tkrop/go-make
 
-go 1.25.0
+go 1.25.1
 
 require (
 	github.com/golang/mock v1.6.0
 	github.com/stretchr/testify v1.11.1
 	github.com/tkrop/go-config v0.0.17
-	github.com/tkrop/go-testing v0.0.28
+	github.com/tkrop/go-testing v0.0.29
 )
 
 require (
@@ -14,6 +14,6 @@ require (
 	github.com/kr/text v0.2.0 // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	github.com/sirupsen/logrus v1.9.3 // indirect
-	golang.org/x/sys v0.35.0 // indirect
+	golang.org/x/sys v0.36.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -18,14 +18,12 @@ github.com/sirupsen/logrus v1.9.3 h1:dueUQJ1C2q9oE3F7wvmSGAaVtTmUizReu6fjN8uqzbQ
 github.com/sirupsen/logrus v1.9.3/go.mod h1:naHLuLoDiP4jHNo9R0sCBMtWGeIprob74mVsIT4qYEQ=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
-github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOfJA=
-github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
 github.com/tkrop/go-config v0.0.17 h1:lCY1tpMevthYsx3pGSn/OD8AKd0/YZTa1XfzpJLGd24=
 github.com/tkrop/go-config v0.0.17/go.mod h1:5LLuMo1rdq/SjfWLPMWvyYCrGVdkZKbmxeX69M15SNI=
-github.com/tkrop/go-testing v0.0.28 h1:F2ajT2i2UDOtftWBxDpGDG00ZJFGXhx5+ixUlYO12Xc=
-github.com/tkrop/go-testing v0.0.28/go.mod h1:6jHRW+iJXFt1ATnyG0ilmfyUC6cwgWyGCa/AHCKn8cY=
+github.com/tkrop/go-testing v0.0.29 h1:uvuGl5V8u/or6HypWRDEMwAeNpp25FqCqCtpNzvEhZ4=
+github.com/tkrop/go-testing v0.0.29/go.mod h1:lx5Eg7cbBTl2+EjK5mf3MiChvigLg0Jcs2NFKN96cTo=
 github.com/yuin/goldmark v1.3.5/go.mod h1:mwnBkeHKe2W/ZEtQ+71ViKU8L12m81fl3OWwC1Zlc8k=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
@@ -41,8 +39,8 @@ golang.org/x/sys v0.0.0-20201119102817-f84b799fce68/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20210330210617-4fbd30eecc44/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210510120138-977fb7262007/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220715151400-c0bba94af5f8/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.35.0 h1:vz1N37gP5bs89s7He8XuIYXpyY0+QlsKmzipCbUtyxI=
-golang.org/x/sys v0.35.0/go.mod h1:BJP2sWEmIv4KK5OTEluFJCKSidICx8ciO85XgH3Ak8k=
+golang.org/x/sys v0.36.0 h1:KVRy2GtZBrk1cBYA7MKu5bEZFxQk4NIDV6RLVcC8o0k=
+golang.org/x/sys v0.36.0/go.mod h1:OgkHotnGiDImocRcuBABYBEXf8A9a87e/uXjp9XT3ks=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.3/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=

--- a/main_test.go
+++ b/main_test.go
@@ -24,5 +24,5 @@ var testMainParams = map[string]test.MainParams{
 }
 
 func TestMain(t *testing.T) {
-	test.Map(t, testMainParams).Run(test.TestMain(main))
+	test.Map(t, testMainParams).Run(test.Main(main))
 }


### PR DESCRIPTION
This pull request updates the dependencies to the latest version including `go-1.25.1`.