### PR TITLE
fix: documentation links (#206)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,7 +15,7 @@ reach via issue.
 ## Reporting bugs
 
 Reporting bugs is one of the best ways to contribute. Before creating a bug
-report, please check whether an [issue](issues) reporting the same problem
+report, please check whether an [issue](../../issues) reporting the same problem
 already exist. If there is such an issue, please add your information as a
 comment.
 
@@ -30,7 +30,7 @@ pull request body.
 
 ## Suggesting features
 
-To request a new feature you should open an [issue](../issues/new) and summarize
+To request a new feature you should open an [issue](../../issues/new) and summarize
 the desired functionality and its use case with an example. Set the issue label
 to "enhancement".
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@
 [build-badge]: <https://github.com/tkrop/go-make/actions/workflows/build.yaml/badge.svg>
 [build-link]: <https://github.com/tkrop/go-make/actions/workflows/build.yaml>
 
-[codeql-badge]: <https://github.com/tkrop/go-make/actions/workflows/codeql-analysis.yml/badge.svg>
+[codeql-badge]: <https://github.com/tkrop/go-make/actions/workflows/github-code-scanning/codeql/badge.svg?branch=main>
 [codeql-link]: <https://github.com/tkrop/go-make/actions/workflows/github-code-scanning/codeql>
 
 [coveralls-badge]: <https://coveralls.io/repos/github/tkrop/go-make/badge.svg?branch=main>


### PR DESCRIPTION
### Description

This pull request fixes some documentation links missed to set correctly in #206.


### Related Issue(s)

fixes #206.


### Testing

Run `make test`, since the code is highly unit tested.


### Checklist

- [x] I have reviewed and tested the changes thoroughly.
- [x] I have added appropriate documentation to the code for clarity.
- [x] I have communicated the consequences of the updates to customers.

Signed-off-by: Tronje Krop <tronje.krop@jactors.de>